### PR TITLE
Removed double declaration for operator"" _Z()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 *.so
 package-lock.json
+cmake-build-debug
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/third_party/boost"]
+	path = src/third_party/boost
+	url = https://github.com/boostorg/boost.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,15 +16,28 @@ include(CTest)
 enable_testing()
 include_directories("${CMAKE_SOURCE_DIR}/src")
 
+
+FetchContent_Declare(
+  boost
+  GIT_REPOSITORY https://github.com/boostorg/boost.git
+  GIT_TAG        boost-1.82.0
+  GIT_PROGRESS 1
+)
+FetchContent_MakeAvailable(boost)
+
+#include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
+#conan_basic_setup()
+#message(STATUS "conanlibs: ${CONAN_LIBS}")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if(WIN32)
-  # Windows-specific flags for MSVC
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /WX /W3")
-else()
-  # Unix-like flags (GCC/Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing -fPIC")
-endif()
+# if(WIN32)
+#   # Windows-specific flags for MSVC
+#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /WX /W3")
+# else()
+#   # Unix-like flags (GCC/Clang)
+#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing -fPIC")
+# endif()
 
 
 set(CC_OPTIMIZE "-O3")
@@ -32,4 +45,5 @@ set(CC_OPTIMIZE "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${CC_OPTIMIZE}")
 
+# add_subdirectory(boost)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,34 +16,10 @@ include(CTest)
 enable_testing()
 include_directories("${CMAKE_SOURCE_DIR}/src")
 
-
-FetchContent_Declare(
-  boost
-  GIT_REPOSITORY https://github.com/boostorg/boost.git
-  GIT_TAG        boost-1.82.0
-  GIT_PROGRESS 1
-)
-FetchContent_MakeAvailable(boost)
-
-#include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
-#conan_basic_setup()
-#message(STATUS "conanlibs: ${CONAN_LIBS}")
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# if(WIN32)
-#   # Windows-specific flags for MSVC
-#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /WX /W3")
-# else()
-#   # Unix-like flags (GCC/Clang)
-#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing -fPIC")
-# endif()
-
-
 set(CC_OPTIMIZE "-O3")
-
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${CC_OPTIMIZE}")
 
-# add_subdirectory(boost)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required (VERSION 3.5)
-if (NOT DEFINED CMAKE_CXX_COMPILER)
-  set(CMAKE_CXX_COMPILER /usr/bin/clang++)
-endif()
-
 project(StarkwareCryptoLib VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -20,12 +16,16 @@ include(CTest)
 enable_testing()
 include_directories("${CMAKE_SOURCE_DIR}/src")
 
-if (NOT DEFINED CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(WIN32)
+  # Windows-specific flags for MSVC
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /WX /W3")
+else()
+  # Unix-like flags (GCC/Clang)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing -fPIC")
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Werror -Wall -Wextra -fno-strict-aliasing -fPIC")
 
 set(CC_OPTIMIZE "-O3")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,15 @@
-add_subdirectory(third_party/boost)
+set(need_boost FALSE)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(need_boost TRUE)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(need_boost TRUE)
+endif()
+
+if(${need_boost})
+    add_subdirectory(third_party/boost)
+endif()
+
 add_subdirectory(starkware)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,10 +4,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(need_boost TRUE)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    set(need_boost TRUE)
-endif()
-
 if(${need_boost})
     add_subdirectory(third_party/boost)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(third_party/boost)
 add_subdirectory(starkware)

--- a/src/starkware/algebra/CMakeLists.txt
+++ b/src/starkware/algebra/CMakeLists.txt
@@ -1,18 +1,22 @@
+if(${need_boost})
+    set(OPTINAL_LIBS Boost::multiprecision)
+endif()
+
 add_library(algebra prime_field_element.cc big_int.h big_int.inl)
-target_link_libraries(algebra PUBLIC Boost::multiprecision)
+target_link_libraries(algebra PUBLIC ${OPTINAL_LIBS})
 
 add_executable(big_int_test big_int_test.cc)
-target_link_libraries(big_int_test gtest gtest_main gmock pthread Boost::multiprecision)
+target_link_libraries(big_int_test gtest gtest_main gmock pthread ${OPTINAL_LIBS})
 add_test(big_int_test big_int_test)
 
 add_executable(prime_field_element_test prime_field_element_test.cc)
-target_link_libraries(prime_field_element_test algebra gtest gtest_main pthread Boost::multiprecision)
+target_link_libraries(prime_field_element_test algebra gtest gtest_main pthread ${OPTINAL_LIBS})
 add_test(prime_field_element_test prime_field_element_test)
 
 add_executable(fraction_field_element_test fraction_field_element_test.cc)
-target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock pthread Boost::multiprecision)
+target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock pthread ${OPTINAL_LIBS})
 add_test(fraction_field_element_test fraction_field_element_test)
 
 add_executable(elliptic_curve_test elliptic_curve_test.cc)
-target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock pthread Boost::multiprecision)
+target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock pthread ${OPTINAL_LIBS})
 add_test(elliptic_curve_test elliptic_curve_test)

--- a/src/starkware/algebra/CMakeLists.txt
+++ b/src/starkware/algebra/CMakeLists.txt
@@ -1,17 +1,21 @@
-add_library(algebra prime_field_element.cc)
+add_library(algebra prime_field_element.cc big_int.h big_int.inl)
+target_link_libraries(algebra PUBLIC Boost::multiprecision)
+# find_package(Boost REQUIRED COMPONENTS multiprecision)
+
+message("keke: ${BOOST_SUPERPROJECT_VERSION}")
 
 add_executable(big_int_test big_int_test.cc)
-target_link_libraries(big_int_test gtest gtest_main gmock pthread)
+target_link_libraries(big_int_test gtest gtest_main gmock pthread Boost::multiprecision)
 add_test(big_int_test big_int_test)
 
 add_executable(prime_field_element_test prime_field_element_test.cc)
-target_link_libraries(prime_field_element_test algebra gtest gtest_main pthread)
+target_link_libraries(prime_field_element_test algebra gtest gtest_main pthread Boost::multiprecision)
 add_test(prime_field_element_test prime_field_element_test)
 
 add_executable(fraction_field_element_test fraction_field_element_test.cc)
-target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock pthread)
+target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock pthread Boost::multiprecision)
 add_test(fraction_field_element_test fraction_field_element_test)
 
 add_executable(elliptic_curve_test elliptic_curve_test.cc)
-target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock pthread)
+target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock pthread Boost::multiprecision)
 add_test(elliptic_curve_test elliptic_curve_test)

--- a/src/starkware/algebra/CMakeLists.txt
+++ b/src/starkware/algebra/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_library(algebra prime_field_element.cc big_int.h big_int.inl)
 target_link_libraries(algebra PUBLIC Boost::multiprecision)
-# find_package(Boost REQUIRED COMPONENTS multiprecision)
-
-message("keke: ${BOOST_SUPERPROJECT_VERSION}")
 
 add_executable(big_int_test big_int_test.cc)
 target_link_libraries(big_int_test gtest gtest_main gmock pthread Boost::multiprecision)

--- a/src/starkware/algebra/CMakeLists.txt
+++ b/src/starkware/algebra/CMakeLists.txt
@@ -2,7 +2,7 @@ if(${need_boost})
     set(OPTIONAL_LIBS Boost::multiprecision)
 endif()
 
-if(NOT WIN_32)
+if(NOT ${WIN_32})
     list(APPEND OPTIONAL_LIBS pthread)
 endif()
 

--- a/src/starkware/algebra/CMakeLists.txt
+++ b/src/starkware/algebra/CMakeLists.txt
@@ -1,22 +1,26 @@
 if(${need_boost})
-    set(OPTINAL_LIBS Boost::multiprecision)
+    set(OPTIONAL_LIBS Boost::multiprecision)
+endif()
+
+if(NOT WIN_32)
+    list(APPEND OPTIONAL_LIBS pthread)
 endif()
 
 add_library(algebra prime_field_element.cc big_int.h big_int.inl)
-target_link_libraries(algebra PUBLIC ${OPTINAL_LIBS})
+target_link_libraries(algebra PUBLIC ${OPTIONAL_LIBS})
 
 add_executable(big_int_test big_int_test.cc)
-target_link_libraries(big_int_test gtest gtest_main gmock pthread ${OPTINAL_LIBS})
+target_link_libraries(big_int_test gtest gtest_main gmock ${OPTIONAL_LIBS})
 add_test(big_int_test big_int_test)
 
 add_executable(prime_field_element_test prime_field_element_test.cc)
-target_link_libraries(prime_field_element_test algebra gtest gtest_main pthread ${OPTINAL_LIBS})
+target_link_libraries(prime_field_element_test algebra gtest gtest_main ${OPTIONAL_LIBS})
 add_test(prime_field_element_test prime_field_element_test)
 
 add_executable(fraction_field_element_test fraction_field_element_test.cc)
-target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock pthread ${OPTINAL_LIBS})
+target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock ${OPTIONAL_LIBS})
 add_test(fraction_field_element_test fraction_field_element_test)
 
 add_executable(elliptic_curve_test elliptic_curve_test.cc)
-target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock pthread ${OPTINAL_LIBS})
+target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock ${OPTIONAL_LIBS})
 add_test(elliptic_curve_test elliptic_curve_test)

--- a/src/starkware/algebra/big_int.h
+++ b/src/starkware/algebra/big_int.h
@@ -91,7 +91,7 @@ class BigInt {
     Returns the representation of the number as a string of the form "0x...".
   */
   std::string ToString() const;
-
+  std::string ToStringDec() const;
   std::vector<bool> ToBoolVector() const;
 
   /*

--- a/src/starkware/algebra/big_int.h
+++ b/src/starkware/algebra/big_int.h
@@ -133,8 +133,6 @@ class BigInt {
 template <size_t N>
 std::ostream& operator<<(std::ostream& os, const BigInt<N>& bigint);
 
-}  // namespace starkware
-
 /*
   Implements the user defined _Z literal that constructs a BigInt of an
   arbitrary size. For example: BigInt<4> a =
@@ -142,6 +140,8 @@ std::ostream& operator<<(std::ostream& os, const BigInt<N>& bigint);
 */
 template <char... Chars>
 static constexpr auto operator"" _Z();
+
+}  // namespace starkware
 
 #include "starkware/algebra/big_int.inl"
 

--- a/src/starkware/algebra/big_int.h
+++ b/src/starkware/algebra/big_int.h
@@ -17,8 +17,8 @@
     Support for 32-bit builds, where __uint128_t isn't defined.
 */
 #ifndef __SIZEOF_INT128__
-  #include <boost/multiprecision/cpp_int.hpp>
-  typedef boost::multiprecision::uint128_t __uint128_t;
+#include <boost/multiprecision/cpp_int.hpp>
+typedef boost::multiprecision::uint128_t __uint128_t;
 #endif
 
 namespace starkware {
@@ -120,6 +120,8 @@ class BigInt {
   constexpr const uint64_t& operator[](int i) const { return gsl::at(value_, i); }
 
   static constexpr size_t LimbCount() { return N; }
+
+  constexpr const std::array<uint64_t, N>& ToLimbs() const { return value_; }
 
   /*
     Returns the number of leading zero's.

--- a/src/starkware/algebra/big_int.inl
+++ b/src/starkware/algebra/big_int.inl
@@ -144,6 +144,15 @@ std::string BigInt<N>::ToString() const {
 }
 
 template <size_t N>
+std::string BigInt<N>::ToStringDec() const {
+  std::ostringstream res;
+  for (int i = N - 1; i >= 0; --i) {
+    res << std::dec << (*this)[i];
+  }
+  return res.str();
+}
+
+template <size_t N>
 std::vector<bool> BigInt<N>::ToBoolVector() const {
   std::vector<bool> res;
   for (uint64_t value : value_) {

--- a/src/starkware/algebra/big_int.inl
+++ b/src/starkware/algebra/big_int.inl
@@ -213,7 +213,7 @@ constexpr size_t BigInt<N>::NumLeadingZeros() const {
   }
 
   if (i >= 0) {
-    res += __builtin_clzll(gsl::at(value_, i));
+    res += LeadingZeros(gsl::at(value_, i));
   }
 
   return res;

--- a/src/starkware/algebra/prime_field_element.h
+++ b/src/starkware/algebra/prime_field_element.h
@@ -49,6 +49,10 @@ class PrimeFieldElement {
         MontgomeryMul(val, kMontgomeryRSquared));
   }
 
+  static constexpr PrimeFieldElement FromMont(const ValueType& val) {
+    return PrimeFieldElement(val);
+  }
+
   static PrimeFieldElement RandomElement(Prng* prng);
 
   static constexpr PrimeFieldElement Zero() { return PrimeFieldElement(ValueType({})); }

--- a/src/starkware/algebra/prime_field_element.h
+++ b/src/starkware/algebra/prime_field_element.h
@@ -115,7 +115,7 @@ class PrimeFieldElement {
   /*
    Returns montgomery representation.
   */
-  constexpr const ValueType& ToMont() { return value_; }
+  constexpr const ValueType& ToMont() const { return value_; }
 
  private:
   explicit constexpr PrimeFieldElement(ValueType val) : value_(val) {}

--- a/src/starkware/algebra/prime_field_element.h
+++ b/src/starkware/algebra/prime_field_element.h
@@ -64,8 +64,8 @@ class PrimeFieldElement {
   }
 
   PrimeFieldElement operator-(const PrimeFieldElement& rhs) const {
-    return PrimeFieldElement{(value_ >= rhs.value_) ? (value_ - rhs.value_)
-                                                    : (value_ + kModulus - rhs.value_)};
+    return PrimeFieldElement{
+        (value_ >= rhs.value_) ? (value_ - rhs.value_) : (value_ + kModulus - rhs.value_)};
   }
 
   PrimeFieldElement operator-() const { return Zero() - *this; }
@@ -111,6 +111,11 @@ class PrimeFieldElement {
   ValueType ToStandardForm() const { return MontgomeryMul(value_, ValueType::One()); }
 
   std::string ToString() const { return ToStandardForm().ToString(); }
+
+  /*
+   Returns montgomery representation.
+  */
+  constexpr const ValueType& ToMont() { return value_; }
 
  private:
   explicit constexpr PrimeFieldElement(ValueType val) : value_(val) {}

--- a/src/starkware/crypto/CMakeLists.txt
+++ b/src/starkware/crypto/CMakeLists.txt
@@ -1,16 +1,20 @@
+if(NOT WIN_32)
+    list(APPEND OPTIONAL_LIBS pthread)
+endif()
+
 add_subdirectory(ffi)
 
 add_library(crypto elliptic_curve_constants.cc pedersen_hash.cc ecdsa.cc)
 target_link_libraries(crypto algebra)
 
 add_executable(elliptic_curve_constants_test elliptic_curve_constants_test.cc)
-target_link_libraries(elliptic_curve_constants_test gtest crypto gtest_main gmock pthread)
+target_link_libraries(elliptic_curve_constants_test gtest crypto gtest_main gmock ${OPTIONAL_LIBS})
 add_test(elliptic_curve_constants_test elliptic_curve_constants_test)
 
 add_executable(pedersen_hash_test pedersen_hash_test.cc)
-target_link_libraries(pedersen_hash_test crypto gtest gtest_main pthread)
+target_link_libraries(pedersen_hash_test crypto gtest gtest_main ${OPTIONAL_LIBS})
 add_test(pedersen_hash_test pedersen_hash_test)
 
 add_executable(ecdsa_test ecdsa_test.cc)
-target_link_libraries(ecdsa_test crypto gtest gtest_main pthread)
+target_link_libraries(ecdsa_test crypto gtest gtest_main ${OPTIONAL_LIBS})
 add_test(ecdsa_test ecdsa_test)

--- a/src/starkware/crypto/CMakeLists.txt
+++ b/src/starkware/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT WIN_32)
+if(NOT ${WIN_32})
     list(APPEND OPTIONAL_LIBS pthread)
 endif()
 

--- a/src/starkware/crypto/ffi/js/package.json
+++ b/src/starkware/crypto/ffi/js/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bigint-buffer": "^1.1.5",
-    "bn": "^1.0.5",
+    "bn.js": "^5.2.0",
     "ffi-napi": "^3.1.0"
   },
   "devDependencies": {

--- a/src/starkware/crypto/ffi/portable_endian.h
+++ b/src/starkware/crypto/ffi/portable_endian.h
@@ -1,0 +1,112 @@
+#ifndef STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_
+#define STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#   define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#   include <endian.h>
+
+#elif defined(__APPLE__)
+
+#   include <libkern/OSByteOrder.h>
+
+#   define htobe16(x) OSSwapHostToBigInt16(x)
+#   define htole16(x) OSSwapHostToLittleInt16(x)
+#   define be16toh(x) OSSwapBigToHostInt16(x)
+#   define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#   define htobe32(x) OSSwapHostToBigInt32(x)
+#   define htole32(x) OSSwapHostToLittleInt32(x)
+#   define be32toh(x) OSSwapBigToHostInt32(x)
+#   define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#   define htobe64(x) OSSwapHostToBigInt64(x)
+#   define htole64(x) OSSwapHostToLittleInt64(x)
+#   define be64toh(x) OSSwapBigToHostInt64(x)
+#   define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#   define __BYTE_ORDER    BYTE_ORDER
+#   define __BIG_ENDIAN    BIG_ENDIAN
+#   define __LITTLE_ENDIAN LITTLE_ENDIAN
+#   define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#   include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#   include <sys/endian.h>
+
+#   define be16toh(x) betoh16(x)
+#   define le16toh(x) letoh16(x)
+
+#   define be32toh(x) betoh32(x)
+#   define le32toh(x) letoh32(x)
+
+#   define be64toh(x) betoh64(x)
+#   define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#   include <winsock2.h>
+#   include <sys/param.h>
+
+#   if BYTE_ORDER == LITTLE_ENDIAN
+
+#      define htobe16(x) htons(x)
+#      define htole16(x) (x)
+#      define be16toh(x) ntohs(x)
+#      define le16toh(x) (x)
+
+#      define htobe32(x) htonl(x)
+#      define htole32(x) (x)
+#      define be32toh(x) ntohl(x)
+#      define le32toh(x) (x)
+
+#      define htobe64(x) htonll(x)
+#      define htole64(x) (x)
+#      define be64toh(x) ntohll(x)
+#      define le64toh(x) (x)
+
+#   elif BYTE_ORDER == BIG_ENDIAN
+
+      /* that would be xbox 360 */
+#      define htobe16(x) (x)
+#      define htole16(x) __builtin_bswap16(x)
+#      define be16toh(x) (x)
+#      define le16toh(x) __builtin_bswap16(x)
+
+#      define htobe32(x) (x)
+#      define htole32(x) __builtin_bswap32(x)
+#      define be32toh(x) (x)
+#      define le32toh(x) __builtin_bswap32(x)
+
+#      define htobe64(x) (x)
+#      define htole64(x) __builtin_bswap64(x)
+#      define be64toh(x) (x)
+#      define le64toh(x) __builtin_bswap64(x)
+
+#   else
+
+#      error byte order not supported
+
+#   endif
+
+#   define __BYTE_ORDER    BYTE_ORDER
+#   define __BIG_ENDIAN    BIG_ENDIAN
+#   define __LITTLE_ENDIAN LITTLE_ENDIAN
+#   define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#   error platform not supported
+
+#endif
+
+#endif  // STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_

--- a/src/starkware/crypto/ffi/portable_endian.h
+++ b/src/starkware/crypto/ffi/portable_endian.h
@@ -108,4 +108,4 @@
 #   error platform not supported
 
 #endif
-
+#endif  // STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_

--- a/src/starkware/crypto/ffi/utils.cc
+++ b/src/starkware/crypto/ffi/utils.cc
@@ -1,8 +1,8 @@
-#include <endian.h>
 #include <algorithm>
 #include <cstring>
 
 #include "starkware/crypto/ffi/utils.h"
+#include "starkware/crypto/ffi/portable_endian.h"
 
 namespace starkware {
 

--- a/src/starkware/starkex/CMakeLists.txt
+++ b/src/starkware/starkex/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT WIN_32)
+if(NOT ${WIN_32})
     list(APPEND OPTIONAL_LIBS pthread)
 endif()
 

--- a/src/starkware/starkex/CMakeLists.txt
+++ b/src/starkware/starkex/CMakeLists.txt
@@ -1,6 +1,10 @@
+if(NOT WIN_32)
+    list(APPEND OPTIONAL_LIBS pthread)
+endif()
+
 add_library(starkex order.cc)
 target_link_libraries(starkex crypto)
 
 add_executable(order_test order_test.cc)
-target_link_libraries(order_test starkex gtest gtest_main gmock pthread)
+target_link_libraries(order_test starkex gtest gtest_main gmock ${OPTIONAL_LIBS})
 add_test(order_test order_test)

--- a/src/starkware/utils/CMakeLists.txt
+++ b/src/starkware/utils/CMakeLists.txt
@@ -1,7 +1,11 @@
+if(NOT WIN_32)
+    list(APPEND OPTIONAL_LIBS pthread)
+endif()
+
 add_executable(math_test math_test.cc)
-target_link_libraries(math_test gtest gtest_main gmock pthread)
+target_link_libraries(math_test gtest gtest_main gmock ${OPTIONAL_LIBS})
 add_test(math_test math_test)
 
 add_executable(prng_test prng_test.cc)
-target_link_libraries(prng_test gtest gtest_main gmock pthread)
+target_link_libraries(prng_test gtest gtest_main gmock ${OPTIONAL_LIBS})
 add_test(prng_test prng_test)

--- a/src/starkware/utils/CMakeLists.txt
+++ b/src/starkware/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT WIN_32)
+if(NOT ${WIN_32})
     list(APPEND OPTIONAL_LIBS pthread)
 endif()
 

--- a/src/starkware/utils/math.h
+++ b/src/starkware/utils/math.h
@@ -15,13 +15,25 @@ constexpr uint64_t inline Pow2(uint64_t n) {
   return UINT64_C(1) << n;
 }
 
+// TODO: rewrite with SFINAE
+constexpr size_t inline LeadingZeros(const uint64_t n) {
+  size_t i = 0;
+  for (uint64_t mask = uint64_t(1) << 63; mask != 0; mask >>= 1, i++) {
+    if (n & mask) {
+      return i;
+    }
+  }
+
+  return i;
+}
+
 /*
   Returns floor(Log_2(n)), n must be > 0.
 */
 constexpr size_t inline Log2Floor(const uint64_t n) {
   ASSERT(n != 0, "log2 of 0 is undefined");
   static_assert(sizeof(long long) == 8, "It is assumed that long long is 64bits");  // NOLINT
-  return 63 - __builtin_clzll(n);
+  return 63 - LeadingZeros(n);
 }
 
 /*

--- a/src/starkware/utils/prng.h
+++ b/src/starkware/utils/prng.h
@@ -21,7 +21,7 @@ class Prng {
     Returns a random integer in the range [0, 2^64).
     Note: This random number generator is NOT cryptographically secure.
   */
-  uint64_t RandomUint64() { return RandomUint64(0, std::numeric_limits<uint64_t>::max()); }
+  uint64_t RandomUint64() { return RandomUint64(0, (std::numeric_limits<uint64_t>::max)()); }
 
  private:
   std::mt19937 mt_prng_;

--- a/src/third_party/gsl/gsl-lite.hpp
+++ b/src/third_party/gsl/gsl-lite.hpp
@@ -2183,7 +2183,7 @@ public:
 #endif
 
     gsl_api gsl_constexpr basic_string_span( pointer ptr )
-    : span_( remove_z( ptr, std::numeric_limits<index_type>::max() ) )
+    : span_( remove_z( ptr, (std::numeric_limits<index_type>::max)() ) )
     {}
 
     gsl_api gsl_constexpr basic_string_span( pointer ptr, index_type count )
@@ -2730,7 +2730,7 @@ gsl_api std::basic_ostream< wchar_t, Traits > & operator<<( std::basic_ostream< 
 namespace details {
 
 template< class T, class SizeType, const T Sentinel >
-gsl_api static span<T> ensure_sentinel( T * seq, SizeType max = std::numeric_limits<SizeType>::max() )
+gsl_api static span<T> ensure_sentinel( T * seq, SizeType max = (std::numeric_limits<SizeType>::max)() )
 {
     typedef T * pointer;
 
@@ -2754,7 +2754,7 @@ gsl_api static span<T> ensure_sentinel( T * seq, SizeType max = std::numeric_lim
 //
 
 template< class T >
-gsl_api inline span<T> ensure_z( T * const & sz, size_t max = std::numeric_limits<size_t>::max() )
+gsl_api inline span<T> ensure_z( T * const & sz, size_t max = (std::numeric_limits<size_t>::max)() )
 {
     return details::ensure_sentinel<T, size_t, 0>( sz, max );
 }


### PR DESCRIPTION
Right now repo contains declaration of `operator"" _Z() `and also `starkware::operator"" _Z()`. This results in undefined symbols when trying to link the library since first declaration isn't actually implemented. I recon it shall be in `starkware` namespace